### PR TITLE
Fix crash

### DIFF
--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -3319,7 +3319,7 @@ void Socket::RingNonFixedWriteCb(int nw) {
         // ring_buf is not null if this is a fixed write of the socket.
         if (req->ring_buf_data.ring_buf != nullptr) {
             // Handle registered buffer write.
-            CHECK(req->ring_buf_data.ring_buf_size >= nw);
+            CHECK(req->ring_buf_data.ring_buf_size >= static_cast<uint32_t>(nw));
             req->ring_buf_data.pop_front(nw);
             bthread::TaskGroup *group = bthread::tls_task_group;
             // The fixed write must be submitted by the same group.
@@ -3409,7 +3409,7 @@ void Socket::NotifyWaitingNonFixedWrite(int nw) {
 
 int Socket::CopyDataRead() {
     bthread::TaskGroup *cur_group = bound_g_;
-    CHECK(buf_idx_ < in_bufs_.size());
+    CHECK(static_cast<uint64_t>(buf_idx_) < in_bufs_.size());
     auto &rbuf = in_bufs_[buf_idx_];
     int nw = rbuf.bytes_;
     if (rbuf.bytes_ > 0) {
@@ -3431,7 +3431,7 @@ int Socket::CopyDataRead() {
 void Socket::ClearInboundBuf() {
     bthread::TaskGroup *cur_group = bthread::tls_task_group;
     CHECK(cur_group == bound_g_);
-    for (; buf_idx_ < in_bufs_.size(); ++buf_idx_) {
+    for (; static_cast<uint64_t>(buf_idx_) < in_bufs_.size(); ++buf_idx_) {
         auto &buf = in_bufs_[buf_idx_];
         if (buf.buf_id_ != UINT16_MAX) {
             cur_group->RecycleRingReadBuf(buf.buf_id_, buf.bytes_);

--- a/src/brpc/socket.h
+++ b/src/brpc/socket.h
@@ -486,7 +486,7 @@ public:
     static int StartInputEvent(SocketId id, uint32_t events,
                                const bthread_attr_t& thread_attr);
 #ifdef IO_URING_ENABLED
-    static void SocketResume(Socket *sock, InboundRingBuf &rbuf,
+    static void SocketResume(SocketUniquePtr sock, InboundRingBuf &rbuf,
                              bthread::TaskGroup *group);
 #endif
 

--- a/src/bthread/ring_listener.cpp
+++ b/src/bthread/ring_listener.cpp
@@ -513,9 +513,7 @@ void RingListener::HandleCqe(io_uring_cqe *cqe) {
             const brpc::SocketId socket_id = recv_data->socket_id_;
             brpc::SocketUniquePtr ptr;
 
-            if (brpc::Socket::Address(socket_id, &ptr) < 0) {
-                LOG(INFO) << "socket is invalid, socket id: " << socket_id;
-            } else {
+            if (brpc::Socket::Address(socket_id, &ptr) == 0) {
                 HandleRecv(std::move(ptr), cqe);
             }
             if (!(cqe->flags & IORING_CQE_F_MORE)) {

--- a/src/bthread/ring_listener.cpp
+++ b/src/bthread/ring_listener.cpp
@@ -164,7 +164,8 @@ int RingListener::SubmitRecv(brpc::Socket *sock) {
     int fd_idx = sock->reg_fd_idx_;
     int sfd = fd_idx >= 0 ? fd_idx : sock->fd();
     io_uring_prep_recv_multishot(sqe, sfd, NULL, 0, 0);
-    uint64_t data = reinterpret_cast<uint64_t>(sock);
+    auto *recv_data = new SocketRecvData(sock->id());
+    auto data = reinterpret_cast<uint64_t>(recv_data);
     data = data << 16;
     data |= OpCodeToInt(OpCode::Recv);
     io_uring_sqe_set_data64(sqe, data);
@@ -508,8 +509,18 @@ void RingListener::HandleCqe(io_uring_cqe *cqe) {
 
     switch (op) {
         case OpCode::Recv: {
-            brpc::Socket *sock = reinterpret_cast<brpc::Socket *>(data >> 16);
-            HandleRecv(sock, cqe);
+            const SocketRecvData *recv_data = reinterpret_cast<SocketRecvData *>(data >> 16);
+            const brpc::SocketId socket_id = recv_data->socket_id_;
+            brpc::SocketUniquePtr ptr;
+
+            if (brpc::Socket::Address(socket_id, &ptr) < 0) {
+                LOG(INFO) << "socket is invalid, socket id: " << socket_id;
+            } else {
+                HandleRecv(std::move(ptr), cqe);
+            }
+            if (!(cqe->flags & IORING_CQE_F_MORE)) {
+                delete recv_data;
+            }
             break;
         }
         case OpCode::CancelRecv: {
@@ -537,10 +548,10 @@ void RingListener::HandleCqe(io_uring_cqe *cqe) {
                 free_reg_fd_idx_.emplace_back(sock->reg_fd_idx_);
                 sock->reg_fd_idx_ = -1;
             }
+            sock->bound_g_ = task_group_;
             int ret = SubmitRecv(sock);
             if (ret == 0) {
                 reg_fds_.try_emplace(sock->fd(), sock->reg_fd_idx_);
-                sock->bound_g_ = task_group_;
                 register_data->Notify(true);
             } else {
                 // SubmitRecv fails, no sqe available. Unregister the sock.
@@ -575,7 +586,7 @@ void RingListener::HandleCqe(io_uring_cqe *cqe) {
     }
 }
 
-void RingListener::HandleRecv(brpc::Socket *sock, io_uring_cqe *cqe) {
+void RingListener::HandleRecv(brpc::SocketUniquePtr sock, io_uring_cqe *cqe) {
     int32_t nw = cqe->res;
     uint16_t buf_id = UINT16_MAX;
     bool need_rearm = false;
@@ -588,8 +599,7 @@ void RingListener::HandleRecv(brpc::Socket *sock, io_uring_cqe *cqe) {
             // There aren't enough buffers for the recv request. Retries the
             // request.
             uint64_t data = OpCodeToInt(OpCode::Recv);
-            bool success = SubmitBacklog(sock, data);
-            if (success) {
+            if (SubmitBacklog(sock.get(), data)) {
                 return;
             }
         }
@@ -615,8 +625,8 @@ void RingListener::HandleRecv(brpc::Socket *sock, io_uring_cqe *cqe) {
         }
     }
 
-    InboundRingBuf in_buf{sock, nw, buf_id, need_rearm};
-    brpc::Socket::SocketResume(sock, in_buf, task_group_);
+    InboundRingBuf in_buf{sock.get(), nw, buf_id, need_rearm};
+    brpc::Socket::SocketResume(std::move(sock), in_buf, task_group_);
 }
 
 void RingListener::HandleBacklog() {

--- a/src/bthread/ring_listener.h
+++ b/src/bthread/ring_listener.h
@@ -87,6 +87,13 @@ struct SocketRegisterData {
     }
 };
 
+struct SocketRecvData {
+    explicit SocketRecvData(const brpc::SocketId socket_id): socket_id_(socket_id) {
+    }
+
+    brpc::SocketId socket_id_;
+};
+
 struct SocketUnRegisterData {
     int fd_;
     int32_t fd_idx_;
@@ -186,6 +193,7 @@ private:
     }
 
     int SubmitRegisterFile(SocketRegisterData *register_data, int *fd, int32_t fd_idx);
+
     int SubmitCancel(SocketUnRegisterData *unregister_data);
 
     void HandleCqe(io_uring_cqe *cqe);
@@ -254,7 +262,7 @@ private:
         }
     }
 
-    void HandleRecv(brpc::Socket *sock, io_uring_cqe *cqe);
+    void HandleRecv(brpc::SocketUniquePtr sock, io_uring_cqe *cqe);
 
     void HandleBacklog();
 

--- a/src/bthread/ring_write_buf_pool.h
+++ b/src/bthread/ring_write_buf_pool.h
@@ -53,7 +53,7 @@ public:
                 perror("getrlimit");
                 LOG(ERROR) << "getrlimit fails";
             } else {
-                int32_t rlim_cur = rl.rlim_cur;
+                const uint32_t rlim_cur = rl.rlim_cur;
                 rl.rlim_cur = 128 * 1024 * 1024;
                 if (rl.rlim_cur > rl.rlim_max) {
                     rl.rlim_cur = rl.rlim_max;


### PR DESCRIPTION
### What problem does this PR solve?

Socket pointers are passed to io_uring entry and can be read data from without checking if they are still invalid. The sockets may already be deleted. Change to passing socket ids to io_uring and check if they are valid when reading data from them.


### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):No

- Breaking backward compatibility(向后兼容性): No

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
