### PR TITLE
rename macros

### DIFF
--- a/src/butil/build_config.h
+++ b/src/butil/build_config.h
@@ -173,6 +173,6 @@
 #define nullptr NULL
 #endif
 
-#define HAVE_DLADDR
+#define BRPC_HAVE_DLADDR
 
 #endif  // BUTIL_BUILD_CONFIG_H_

--- a/src/butil/third_party/symbolize/symbolize.cc
+++ b/src/butil/third_party/symbolize/symbolize.cc
@@ -796,7 +796,7 @@ static ATTRIBUTE_NOINLINE bool SymbolizeAndDemangle(void *pc, char *out,
 
 _END_GOOGLE_NAMESPACE_
 
-#elif defined(OS_MACOSX) && defined(HAVE_DLADDR)
+#elif defined(OS_MACOSX) && defined(BRPC_HAVE_DLADDR)
 
 #include <dlfcn.h>
 #include <string.h>


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

HAVE_DLADDR is conflict with other modules, rename it with prefix.

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响): No

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
