### PR TITLE
Fix module registration replacement tracking

### DIFF
--- a/src/bthread/eloq_module.cpp
+++ b/src/bthread/eloq_module.cpp
@@ -28,6 +28,7 @@ bthread::TaskControl *bthread_get_task_control();
 
 extern std::array<eloq::EloqModule *, 10> registered_modules;
 extern std::atomic<int> registered_module_cnt;
+extern std::atomic<uint64_t> registered_module_version;
 
 namespace eloq {
     bool EloqModule::NotifyWorker(int thd_id) {
@@ -44,6 +45,7 @@ namespace eloq {
         }
         registered_modules[i] = module;
         registered_module_cnt.fetch_add(1, std::memory_order_release);
+        registered_module_version.fetch_add(1, std::memory_order_release);
         const auto non_null_modules =
                 std::count_if(registered_modules.begin(), registered_modules.end(),
                               [](EloqModule *registered_module) {
@@ -88,6 +90,7 @@ namespace eloq {
         }
         registered_modules[registered_modules.size() - 1] = nullptr;
         registered_module_cnt.fetch_sub(1, std::memory_order_release);
+        registered_module_version.fetch_add(1, std::memory_order_release);
         const auto non_null_modules =
                 std::count_if(registered_modules.begin(), registered_modules.end(),
                               [](EloqModule *registered_module) {

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -47,6 +47,7 @@
 
 std::array<eloq::EloqModule *, 10> registered_modules;
 std::atomic<int> registered_module_cnt;
+std::atomic<uint64_t> registered_module_version;
 
 DEFINE_int32(steal_task_rnd, 100, "Steal task frequency in wait_task");
 DEFINE_bool(brpc_worker_as_ext_processor, false, "Work as external processor");
@@ -1316,8 +1317,12 @@ bool TaskGroup::HasTasks() {
 }
 
 void TaskGroup::CheckAndUpdateModules() {
-    if (modules_cnt_ != registered_module_cnt.load(std::memory_order_acquire)) {
+    const uint64_t global_version =
+        registered_module_version.load(std::memory_order_acquire);
+    if (modules_version_ != global_version) {
         std::shared_lock lk(eloq::module_mutex);
+        const uint64_t current_version =
+            registered_module_version.load(std::memory_order_acquire);
         const int registered_module_count =
                 registered_module_cnt.load(std::memory_order_acquire);
         const auto old_registered_modules = registered_modules_;
@@ -1327,27 +1332,35 @@ void TaskGroup::CheckAndUpdateModules() {
             return module != nullptr;
         });
         CHECK_EQ(static_cast<int>(new_module_cnt), registered_module_count);
-        // new modules
-        for (auto i = modules_cnt_; i < new_module_cnt; ++i) {
-            registered_modules_[i]->registered_workers_.fetch_add(1, std::memory_order_relaxed);
+
+        for (auto* new_m : registered_modules_) {
+            if (new_m == nullptr) {
+                continue;
+            }
+            const bool found = std::find(old_registered_modules.begin(),
+                                         old_registered_modules.end(),
+                                         new_m) != old_registered_modules.end();
+            if (!found) {
+                new_m->registered_workers_.fetch_add(
+                    1, std::memory_order_relaxed);
+            }
         }
-        // deleted modules
-        if (new_module_cnt < modules_cnt_) {
-            for (auto* old_m : old_registered_modules) {
-                bool found = false;
-                for (auto* new_m : registered_modules_) {
-                    if (new_m == old_m) {
-                        found = true;
-                        break;
-                    }
-                }
-                if (!found) {
-                    old_m->registered_workers_.fetch_sub(1, std::memory_order_relaxed);
-                }
+
+        for (auto* old_m : old_registered_modules) {
+            if (old_m == nullptr) {
+                continue;
+            }
+            const bool found = std::find(registered_modules_.begin(),
+                                         registered_modules_.end(),
+                                         old_m) != registered_modules_.end();
+            if (!found) {
+                old_m->registered_workers_.fetch_sub(
+                    1, std::memory_order_relaxed);
             }
         }
 
         modules_cnt_ = static_cast<int>(new_module_cnt);
+        modules_version_ = current_version;
     }
 }
 

--- a/src/bthread/task_group.h
+++ b/src/bthread/task_group.h
@@ -229,6 +229,7 @@ public:
 
     std::array<eloq::EloqModule *, 10> registered_modules_{};
     int modules_cnt_{0};
+    uint64_t modules_version_{0};
 
 #ifdef IO_URING_ENABLED
     int RegisterSocket(SocketRegisterData *data);


### PR DESCRIPTION
## Summary

Fix `EloqModule` registration bookkeeping when one module is registered while another module is unregistered and the total module count ends up unchanged.

The previous `TaskGroup::CheckAndUpdateModules()` used only `registered_module_cnt` to decide whether a worker needed to refresh its local module list. That misses replacement cases such as:

1. Worker local state is `[EloqStoreModule]`, `modules_cnt_ == 1`.
2. A second module is registered, global state becomes `[EloqStoreModule, TxServiceModule]`, count `2`.
3. Before this worker observes count `2`, `EloqStoreModule` is unregistered, global state becomes `[TxServiceModule]`, count `1`.
4. The worker sees local count `1` and global count `1`, skips the refresh, and never decrements `EloqStoreModule::registered_workers_`.

That can make `unregister_module(EloqStoreModule)` wait forever for `registered_workers_` to reach zero.

## Changes

- Add a global `registered_module_version` that increments on every register/unregister.
- Track each worker's local observed module version.
- Refresh worker module state when the version changes, not only when the count changes.
- Compute added/removed modules by pointer comparison so replacements with the same count correctly update `registered_workers_`.

## Validation

Validated in EloqKV with a reproduced startup race where `EloqStoreModule` unregister overlaps `TxServiceModule` registration:

- Before this fix, logs showed `unregister_module` stuck with `registered_workers=1` indefinitely.
- With this fix, the same path completed `unregister_module`, `EloqStore` stopped, restarted, and `DataSubstrate` reached started state.

Built locally:

- `cmake --build /mnt/1t/eloqkv/data_substrate/third_party/build/brpc --target install -j2`
- `cmake --build /mnt/1t/eloqkv/bld --target eloqkv -j2`
