### PR TITLE
feat: wake io_uring workers through eventfd

### DIFF
--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -64,6 +64,9 @@
 DEFINE_bool(dispatch_lazily, false, "dispatcher lazily creates task");
 #ifdef IO_URING_ENABLED
 DEFINE_bool(use_io_uring, false, "Use IO URING to do the polling.");
+DEFINE_bool(brpc_use_event_fd_wakeup, false,
+            "Wake up idle brpc workers through eventfd polled by io_uring. "
+            "Requires use_io_uring and is fixed at startup.");
 #endif
 
 namespace bthread {

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -64,7 +64,7 @@
 DEFINE_bool(dispatch_lazily, false, "dispatcher lazily creates task");
 #ifdef IO_URING_ENABLED
 DEFINE_bool(use_io_uring, false, "Use IO URING to do the polling.");
-DEFINE_bool(brpc_use_event_fd_wakeup, false,
+DEFINE_bool(brpc_use_event_fd_wakeup, true,
             "Wake up idle brpc workers through eventfd polled by io_uring. "
             "Requires use_io_uring and is fixed at startup.");
 #endif

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -64,9 +64,6 @@
 DEFINE_bool(dispatch_lazily, false, "dispatcher lazily creates task");
 #ifdef IO_URING_ENABLED
 DEFINE_bool(use_io_uring, false, "Use IO URING to do the polling.");
-DEFINE_bool(brpc_use_event_fd_wakeup, true,
-            "Wake up idle brpc workers through eventfd polled by io_uring. "
-            "Requires use_io_uring and is fixed at startup.");
 #endif
 
 namespace bthread {

--- a/src/bthread/ring_listener.cpp
+++ b/src/bthread/ring_listener.cpp
@@ -479,9 +479,9 @@ void RingListener::DrainEventFd() {
         if (nread < 0 && errno == EINTR) {
             continue;
         }
-        // EAGAIN means another notification consumer already drained the
-        // counter. There is only one consumer today, but treating it as
-        // drained keeps this helper safe if that implementation changes.
+        // Multiple multishot CQEs may already be queued for the same readable
+        // eventfd. An earlier CQE can drain the coalesced counter, leaving a
+        // later one with nothing to read.
         if (nread < 0 && errno == EAGAIN) {
             return;
         }

--- a/src/bthread/ring_listener.cpp
+++ b/src/bthread/ring_listener.cpp
@@ -513,7 +513,7 @@ void RingListener::NotifyEventFd() {
     }
 }
 
-int RingListener::WaitForCqe() {
+int RingListener::Park() {
     int ret;
     do {
         ret = io_uring_submit_and_wait(&ring_, 1);

--- a/src/bthread/ring_listener.cpp
+++ b/src/bthread/ring_listener.cpp
@@ -46,7 +46,7 @@ DEFINE_int32(io_uring_registered_files, 1024,
              "inbound listener");
 DEFINE_int32(io_uring_write_buffer_pool_size, 1024,
              "Number of buffers kept in the io_uring-based write buffer pool.");
-DECLARE_bool(brpc_use_event_fd_wakeup);
+DECLARE_bool(use_io_uring);
 
 void RingListener::Close() {
     if (ring_init_) {
@@ -66,7 +66,7 @@ void RingListener::Close() {
 }
 
 RingListener::~RingListener() {
-    if (!FLAGS_brpc_use_event_fd_wakeup) {
+    if (!FLAGS_use_io_uring) {
         for (auto [fd, fd_idx]: reg_fds_) {
             SocketUnRegisterData data;
             data.fd_ = fd;
@@ -135,10 +135,9 @@ int RingListener::Init() {
 
     const unsigned write_buf_slots = static_cast<unsigned>(flag_write_buffers);
 
-    unsigned ring_flags = IORING_SETUP_SINGLE_ISSUER;
-    if (FLAGS_brpc_use_event_fd_wakeup) {
-        ring_flags |= IORING_SETUP_DEFER_TASKRUN | IORING_SETUP_TASKRUN_FLAG;
-    }
+    unsigned ring_flags = IORING_SETUP_SINGLE_ISSUER |
+                          IORING_SETUP_DEFER_TASKRUN |
+                          IORING_SETUP_TASKRUN_FLAG;
     int ret = io_uring_queue_init(queue_entries, &ring_, ring_flags);
 
     if (ret < 0) {
@@ -237,7 +236,7 @@ int RingListener::Init() {
     }
 
     poll_status_.store(PollStatus::Sleep, std::memory_order_release);
-    if (FLAGS_brpc_use_event_fd_wakeup) {
+    if (FLAGS_use_io_uring) {
         wakeup_event_fd_ = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
         if (wakeup_event_fd_ < 0) {
             const int saved_errno = errno;
@@ -627,7 +626,7 @@ size_t RingListener::ExtPoll() {
 }
 
 void RingListener::ExtWakeup() {
-    if (FLAGS_brpc_use_event_fd_wakeup) {
+    if (FLAGS_use_io_uring) {
         return;
     }
     has_external_.store(false, std::memory_order_relaxed);

--- a/src/bthread/ring_listener.cpp
+++ b/src/bthread/ring_listener.cpp
@@ -739,11 +739,16 @@ void RingListener::HandleCqe(io_uring_cqe *cqe) {
                            << cqe->res;
             }
             DrainEventFd();
-            // A multishot poll stays armed after each readiness event. Losing
-            // IORING_CQE_F_MORE means the scheduler can no longer wake this
-            // worker, so fail instead of allowing a future permanent sleep.
+            // A multishot poll stays armed only while the CQE carries MORE.
+            // Re-arm a terminated request so a later scheduler notification
+            // cannot leave this worker permanently asleep.
             if (!(cqe->flags & IORING_CQE_F_MORE)) {
-                LOG(FATAL) << "The brpc worker multishot wakeup poll terminated";
+                const int ret = ArmEventFdPoll();
+                if (ret != 0) {
+                    LOG(ERROR) << "Failed to re-arm the brpc worker wakeup "
+                                  "poll, ret: "
+                               << ret;
+                }
             }
             break;
         }

--- a/src/bthread/ring_listener.cpp
+++ b/src/bthread/ring_listener.cpp
@@ -530,7 +530,7 @@ int RingListener::Park() {
     if (ret == -EINTR || ret == -EBUSY) {
         return ret;
     }
-    LOG(FATAL) << "Failed while waiting on the brpc worker io_uring, ret: " << ret;
+    LOG(ERROR) << "Failed while waiting on the brpc worker io_uring, ret: " << ret;
     return ret;
 }
 

--- a/src/bthread/ring_listener.cpp
+++ b/src/bthread/ring_listener.cpp
@@ -233,7 +233,6 @@ int RingListener::Init() {
             std::make_unique<RingWriteBufferPool>(write_buf_slots, &ring_);
 
     if (write_buf_pool_->buf_pool_.empty()) {
-        Close();
         return -1;
     }
 
@@ -244,17 +243,14 @@ int RingListener::Init() {
             const int saved_errno = errno;
             LOG(ERROR) << "Failed to create the brpc worker wakeup eventfd, errno: "
                        << saved_errno << " (" << strerror(saved_errno) << ")";
-            Close();
             return -saved_errno;
         }
         ret = ArmEventFdPoll();
         if (ret != 0) {
-            Close();
             return ret;
         }
         ret = SubmitAll();
         if (ret < 0) {
-            Close();
             return ret;
         }
     } else {

--- a/src/bthread/ring_listener.cpp
+++ b/src/bthread/ring_listener.cpp
@@ -525,8 +525,9 @@ int RingListener::Park() {
         return 0;
     }
     // TaskControl interrupts worker pthreads during shutdown. Returning on
-    // EINTR lets the scheduler observe the stopped parking-lot state.
-    if (ret == -EINTR) {
+    // EINTR lets the scheduler observe the stopped parking-lot state. EBUSY
+    // means the CQ overflow list must be reaped before entering the ring again.
+    if (ret == -EINTR || ret == -EBUSY) {
         return ret;
     }
     LOG(FATAL) << "Failed while waiting on the brpc worker io_uring, ret: " << ret;

--- a/src/bthread/ring_listener.cpp
+++ b/src/bthread/ring_listener.cpp
@@ -21,8 +21,11 @@
 #include <cstdint>
 #include <errno.h>
 #include <cstring>
+#include <poll.h>
 #include <string>
 #include <sys/resource.h>
+#include <sys/eventfd.h>
+#include <unistd.h>
 
 #include <gflags/gflags.h>
 
@@ -43,19 +46,39 @@ DEFINE_int32(io_uring_registered_files, 1024,
              "inbound listener");
 DEFINE_int32(io_uring_write_buffer_pool_size, 1024,
              "Number of buffers kept in the io_uring-based write buffer pool.");
+DECLARE_bool(brpc_use_event_fd_wakeup);
+
+void RingListener::Close() {
+    if (ring_init_) {
+        io_uring_queue_exit(&ring_);
+        ring_init_ = false;
+    }
+
+    if (wakeup_event_fd_ >= 0) {
+        close(wakeup_event_fd_);
+        wakeup_event_fd_ = -1;
+    }
+
+    if (in_buf_) {
+        free(in_buf_);
+        in_buf_ = nullptr;
+    }
+}
 
 RingListener::~RingListener() {
-    for (auto [fd, fd_idx]: reg_fds_) {
-        SocketUnRegisterData data;
-        data.fd_ = fd;
-        SubmitCancel(&data);
-        // Not wait here because the worker should have quit already.
-    }
-    SubmitAll();
+    if (!FLAGS_brpc_use_event_fd_wakeup) {
+        for (auto [fd, fd_idx]: reg_fds_) {
+            SocketUnRegisterData data;
+            data.fd_ = fd;
+            SubmitCancel(&data);
+            // Not wait here because the worker should have quit already.
+        }
+        SubmitAll();
 
-    poll_status_.store(PollStatus::Closed, std::memory_order_release); {
-        std::unique_lock<std::mutex> lk(mux_);
-        cv_.notify_one();
+        poll_status_.store(PollStatus::Closed, std::memory_order_release); {
+            std::unique_lock<std::mutex> lk(mux_);
+            cv_.notify_one();
+        }
     }
 
     if (poll_thd_.joinable()) {
@@ -112,7 +135,11 @@ int RingListener::Init() {
 
     const unsigned write_buf_slots = static_cast<unsigned>(flag_write_buffers);
 
-    int ret = io_uring_queue_init(queue_entries, &ring_, IORING_SETUP_SINGLE_ISSUER);
+    unsigned ring_flags = IORING_SETUP_SINGLE_ISSUER;
+    if (FLAGS_brpc_use_event_fd_wakeup) {
+        ring_flags |= IORING_SETUP_DEFER_TASKRUN | IORING_SETUP_TASKRUN_FLAG;
+    }
+    int ret = io_uring_queue_init(queue_entries, &ring_, ring_flags);
 
     if (ret < 0) {
         LOG(WARNING) << "Failed to initialize the IO uring of the inbound "
@@ -206,17 +233,39 @@ int RingListener::Init() {
             std::make_unique<RingWriteBufferPool>(write_buf_slots, &ring_);
 
     if (write_buf_pool_->buf_pool_.empty()) {
+        Close();
         return -1;
     }
 
     poll_status_.store(PollStatus::Sleep, std::memory_order_release);
-    poll_thd_ = std::thread([&]() {
-        std::string ring_listener = "ring_listener:";
-        ring_listener.append(std::to_string(task_group_->group_id_));
-        butil::PlatformThread::SetName(ring_listener.c_str());
+    if (FLAGS_brpc_use_event_fd_wakeup) {
+        wakeup_event_fd_ = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+        if (wakeup_event_fd_ < 0) {
+            const int saved_errno = errno;
+            LOG(ERROR) << "Failed to create the brpc worker wakeup eventfd, errno: "
+                       << saved_errno << " (" << strerror(saved_errno) << ")";
+            Close();
+            return -saved_errno;
+        }
+        ret = ArmEventFdPoll();
+        if (ret != 0) {
+            Close();
+            return ret;
+        }
+        ret = SubmitAll();
+        if (ret < 0) {
+            Close();
+            return ret;
+        }
+    } else {
+        poll_thd_ = std::thread([&]() {
+            std::string ring_listener = "ring_listener:";
+            ring_listener.append(std::to_string(task_group_->group_id_));
+            butil::PlatformThread::SetName(ring_listener.c_str());
 
-        Run();
-    });
+            Run();
+        });
+    }
 
     return 0;
 }
@@ -443,6 +492,83 @@ int RingListener::SubmitAll() {
     return ret;
 }
 
+int RingListener::ArmEventFdPoll() {
+    io_uring_sqe *sqe = io_uring_get_sqe(&ring_);
+    if (sqe == nullptr) {
+        LOG(ERROR) << "Failed to get an SQE for the brpc worker wakeup eventfd";
+        return -EAGAIN;
+    }
+
+    io_uring_prep_poll_multishot(sqe, wakeup_event_fd_, POLLIN);
+    io_uring_sqe_set_data64(sqe, OpCodeToInt(OpCode::SchedulerWakeup));
+    ++submit_cnt_;
+    return 0;
+}
+
+void RingListener::DrainEventFd() {
+    uint64_t value = 0;
+    while (true) {
+        const ssize_t nread = read(wakeup_event_fd_, &value, sizeof(value));
+        if (nread == static_cast<ssize_t>(sizeof(value))) {
+            return;
+        }
+        if (nread < 0 && errno == EINTR) {
+            continue;
+        }
+        // EAGAIN means another notification consumer already drained the
+        // counter. There is only one consumer today, but treating it as
+        // drained keeps this helper safe if that implementation changes.
+        if (nread < 0 && errno == EAGAIN) {
+            return;
+        }
+        const int saved_errno = errno;
+        LOG(FATAL) << "Failed to drain the brpc worker wakeup eventfd, errno: "
+                   << saved_errno << " (" << strerror(saved_errno) << ")";
+    }
+}
+
+void RingListener::NotifyEventFd() {
+    const uint64_t one = 1;
+    while (true) {
+        const ssize_t nwritten = write(wakeup_event_fd_, &one, sizeof(one));
+        if (nwritten == static_cast<ssize_t>(sizeof(one))) {
+            return;
+        }
+        if (nwritten < 0 && errno == EINTR) {
+            continue;
+        }
+        // A saturated eventfd is already readable, so the outstanding poll is
+        // sufficient to wake the worker. Notifications are also coalesced by
+        // TaskGroup::_notified, making this path exceptional.
+        if (nwritten < 0 && errno == EAGAIN) {
+            return;
+        }
+        const int saved_errno = errno;
+        LOG(FATAL) << "Failed to notify the brpc worker wakeup eventfd, errno: "
+                   << saved_errno << " (" << strerror(saved_errno) << ")";
+    }
+}
+
+int RingListener::WaitForCqe() {
+    int ret;
+    do {
+        ret = io_uring_submit_and_wait(&ring_, 1);
+    } while (ret == -EAGAIN);
+
+    if (ret >= 0) {
+        submit_cnt_ = submit_cnt_ >= ret ? submit_cnt_ - ret : 0;
+        cqe_ready_.store(true, std::memory_order_relaxed);
+        return 0;
+    }
+    // TaskControl interrupts worker pthreads during shutdown. Returning on
+    // EINTR lets the scheduler observe the stopped parking-lot state.
+    if (ret == -EINTR) {
+        return ret;
+    }
+    LOG(FATAL) << "Failed while waiting on the brpc worker io_uring, ret: " << ret;
+    return ret;
+}
+
 void RingListener::PollAndNotify() {
     io_uring_cqe *cqe = nullptr;
     while (true) {
@@ -505,6 +631,9 @@ size_t RingListener::ExtPoll() {
 }
 
 void RingListener::ExtWakeup() {
+    if (FLAGS_brpc_use_event_fd_wakeup) {
+        return;
+    }
     has_external_.store(false, std::memory_order_relaxed);
     if (poll_status_.load(std::memory_order_relaxed) != PollStatus::Sleep) {
         return;
@@ -709,6 +838,20 @@ void RingListener::HandleCqe(io_uring_cqe *cqe) {
             RingFsyncData *fsync_data = reinterpret_cast<RingFsyncData *>(data >> 16);
             int res = cqe->res;
             fsync_data->Notify(res);
+            break;
+        }
+        case OpCode::SchedulerWakeup: {
+            if (cqe->res < 0) {
+                LOG(FATAL) << "The brpc worker wakeup poll failed, ret: "
+                           << cqe->res;
+            }
+            DrainEventFd();
+            // A multishot poll stays armed after each readiness event. Losing
+            // IORING_CQE_F_MORE means the scheduler can no longer wake this
+            // worker, so fail instead of allowing a future permanent sleep.
+            if (!(cqe->flags & IORING_CQE_F_MORE)) {
+                LOG(FATAL) << "The brpc worker multishot wakeup poll terminated";
+            }
             break;
         }
         default:

--- a/src/bthread/ring_listener.cpp
+++ b/src/bthread/ring_listener.cpp
@@ -34,7 +34,6 @@
 #include "bthread/eloq_module.h"
 #include "bthread/inbound_ring_buf.h"
 #include "bthread/ring_write_buf_pool.h"
-#include "butil/threading/platform_thread.h"
 
 #include "ring_listener.h"
 
@@ -46,7 +45,6 @@ DEFINE_int32(io_uring_registered_files, 1024,
              "inbound listener");
 DEFINE_int32(io_uring_write_buffer_pool_size, 1024,
              "Number of buffers kept in the io_uring-based write buffer pool.");
-DECLARE_bool(use_io_uring);
 
 void RingListener::Close() {
     if (ring_init_) {
@@ -66,24 +64,6 @@ void RingListener::Close() {
 }
 
 RingListener::~RingListener() {
-    if (!FLAGS_use_io_uring) {
-        for (auto [fd, fd_idx]: reg_fds_) {
-            SocketUnRegisterData data;
-            data.fd_ = fd;
-            SubmitCancel(&data);
-            // Not wait here because the worker should have quit already.
-        }
-        SubmitAll();
-
-        poll_status_.store(PollStatus::Closed, std::memory_order_release); {
-            std::unique_lock<std::mutex> lk(mux_);
-            cv_.notify_one();
-        }
-    }
-
-    if (poll_thd_.joinable()) {
-        poll_thd_.join();
-    }
     Close();
 }
 
@@ -235,31 +215,20 @@ int RingListener::Init() {
         return -1;
     }
 
-    poll_status_.store(PollStatus::Sleep, std::memory_order_release);
-    if (FLAGS_use_io_uring) {
-        wakeup_event_fd_ = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
-        if (wakeup_event_fd_ < 0) {
-            const int saved_errno = errno;
-            LOG(ERROR) << "Failed to create the brpc worker wakeup eventfd, errno: "
-                       << saved_errno << " (" << strerror(saved_errno) << ")";
-            return -saved_errno;
-        }
-        ret = ArmEventFdPoll();
-        if (ret != 0) {
-            return ret;
-        }
-        ret = SubmitAll();
-        if (ret < 0) {
-            return ret;
-        }
-    } else {
-        poll_thd_ = std::thread([&]() {
-            std::string ring_listener = "ring_listener:";
-            ring_listener.append(std::to_string(task_group_->group_id_));
-            butil::PlatformThread::SetName(ring_listener.c_str());
-
-            Run();
-        });
+    wakeup_event_fd_ = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+    if (wakeup_event_fd_ < 0) {
+        const int saved_errno = errno;
+        LOG(ERROR) << "Failed to create the brpc worker wakeup eventfd, errno: "
+                   << saved_errno << " (" << strerror(saved_errno) << ")";
+        return -saved_errno;
+    }
+    ret = ArmEventFdPoll();
+    if (ret != 0) {
+        return ret;
+    }
+    ret = SubmitAll();
+    if (ret < 0) {
+        return ret;
     }
 
     return 0;
@@ -564,46 +533,12 @@ int RingListener::WaitForCqe() {
     return ret;
 }
 
-void RingListener::PollAndNotify() {
-    io_uring_cqe *cqe = nullptr;
-    while (true) {
-        int ret = io_uring_wait_cqe(&ring_, &cqe);
-        if (ret == -EINTR || ret == -EAGAIN) {
-            continue;
-        }
-        if (ret < 0) {
-            LOG(ERROR) << "Listener uring wait errno: " << ret;
-            poll_status_.store(PollStatus::Sleep, std::memory_order_relaxed);
-            return;
-        }
-        break;
-    }
-
-    cqe_ready_.store(true, std::memory_order_relaxed);
-    poll_status_.store(PollStatus::Sleep, std::memory_order_relaxed);
-    RingModule::NotifyWorker(task_group_->group_id_);
-}
-
-
 size_t RingListener::ExtPoll() {
-    if (!has_external_.load(std::memory_order_relaxed)) {
-        has_external_.store(true, std::memory_order_release);
-    }
-
-    // has_external_ should be updated before poll_status_ is checked.
-    std::atomic_thread_fence(std::memory_order_release);
-
-    PollStatus status = PollStatus::Sleep;
-    if (!poll_status_.compare_exchange_strong(status, PollStatus::ExtPoll)) {
-        return 0;
-    }
-
     HandleBacklog();
 
     io_uring_cqe *cqe = nullptr;
     int ret = io_uring_peek_cqe(&ring_, &cqe);
     if (ret != 0) {
-        poll_status_.store(PollStatus::Sleep, std::memory_order_relaxed);
         return 0;
     }
 
@@ -614,49 +549,12 @@ size_t RingListener::ExtPoll() {
         ++processed;
     }
 
-    cqe_ready_.store(false, std::memory_order_relaxed);
-
     if (processed > 0) {
         io_uring_cq_advance(&ring_, processed);
     }
     cqe_ready_.store(false, std::memory_order_relaxed);
-    poll_status_.store(PollStatus::Sleep, std::memory_order_relaxed);
 
     return processed;
-}
-
-void RingListener::ExtWakeup() {
-    if (FLAGS_use_io_uring) {
-        return;
-    }
-    has_external_.store(false, std::memory_order_relaxed);
-    if (poll_status_.load(std::memory_order_relaxed) != PollStatus::Sleep) {
-        return;
-    }
-    std::unique_lock<std::mutex> lk(mux_);
-    cv_.notify_one();
-}
-
-void RingListener::Run() {
-    while (poll_status_.load(std::memory_order_relaxed) != PollStatus::Closed) {
-        bool success = false;
-        if (!has_external_.load(std::memory_order_relaxed)) {
-            PollStatus status = PollStatus::Sleep;
-            success = poll_status_.compare_exchange_strong(status, PollStatus::Active,
-                                                           std::memory_order_acq_rel);
-            if (success) {
-                PollAndNotify();
-            }
-        }
-        std::unique_lock<std::mutex> lk(mux_);
-        cv_.wait(lk, [this]() {
-            // wait for the worker to process the ready cqes and notify RingListener when it sleeps
-            return !has_external_.load(std::memory_order_relaxed)
-                   && !cqe_ready_.load(std::memory_order_relaxed) ||
-                   poll_status_.load(std::memory_order_relaxed) ==
-                   PollStatus::Closed;
-        });
-    }
 }
 
 void RingListener::RecycleReadBuf(uint16_t bid, size_t bytes) {

--- a/src/bthread/ring_listener.h
+++ b/src/bthread/ring_listener.h
@@ -21,12 +21,9 @@
 
 #ifdef IO_URING_ENABLED
 
-#include <condition_variable>
 #include <butil/logging.h>
-#include <iostream>
 #include <liburing.h>
 #include <mutex>
-#include <thread>
 #include <unordered_map>
 
 #include "brpc/socket.h"
@@ -34,7 +31,6 @@
 #undef BLOCK_SIZE
 #include "bthread/moodycamelqueue.h"
 #include "bthread/ring_write_buf_pool.h"
-#include "butil/threading/platform_thread.h"
 #include "spsc_queue.h"
 
 namespace bthread {
@@ -157,11 +153,7 @@ public:
 
     int SubmitAll();
 
-    void PollAndNotify();
-
     size_t ExtPoll();
-
-    void ExtWakeup();
 
     // Wakes an io_uring worker blocked in WaitForCqe through the poll request
     // registered on wakeup_event_fd_.
@@ -171,8 +163,6 @@ public:
     // DEFER_TASKRUN requires every io_uring_enter call to come from the ring's
     // single issuer, so the legacy polling thread must never call this method.
     int WaitForCqe();
-
-    void Run();
 
     void RecycleReadBuf(uint16_t bid, size_t bytes);
 
@@ -279,18 +269,13 @@ private:
 
     void DrainEventFd();
 
-    enum struct PollStatus : uint8_t { Active = 0, Sleep, ExtPoll, Closed };
-
     struct io_uring ring_;
     bool ring_init_{false};
-    std::atomic<PollStatus> poll_status_{PollStatus::Sleep};
-    // cqe_ready_ is set by the ring listener and unset by the worker
+    // cqe_ready_ is set before a parked worker resumes and cleared after the
+    // owning worker drains the completion queue.
     std::atomic<bool> cqe_ready_{false};
     uint16_t submit_cnt_{0};
     std::unordered_map<int, int> reg_fds_;
-    std::mutex mux_;
-    std::condition_variable cv_;
-    std::thread poll_thd_;
     int wakeup_event_fd_{-1};
 
     io_uring_buf_ring *in_buf_ring_{nullptr};
@@ -305,8 +290,6 @@ private:
     std::vector<std::pair<brpc::Socket *, uint64_t> > waiting_batch_{
         buf_ring_size
     };
-
-    std::atomic<bool> has_external_{true};
 
     std::vector<uint16_t> free_reg_fd_idx_;
 

--- a/src/bthread/ring_listener.h
+++ b/src/bthread/ring_listener.h
@@ -155,14 +155,14 @@ public:
 
     size_t ExtPoll();
 
-    // Wakes an io_uring worker blocked in WaitForCqe through the poll request
+    // Wakes an io_uring worker blocked in Park() through the poll request
     // registered on wakeup_event_fd_.
     void NotifyEventFd();
 
     // Blocks the owning worker until this ring has at least one completion.
     // DEFER_TASKRUN requires every io_uring_enter call to come from the ring's
     // single issuer, so the legacy polling thread must never call this method.
-    int WaitForCqe();
+    int Park();
 
     void RecycleReadBuf(uint16_t bid, size_t bytes);
 

--- a/src/bthread/ring_listener.h
+++ b/src/bthread/ring_listener.h
@@ -160,8 +160,6 @@ public:
     void NotifyEventFd();
 
     // Blocks the owning worker until this ring has at least one completion.
-    // DEFER_TASKRUN requires every io_uring_enter call to come from the ring's
-    // single issuer, so the legacy polling thread must never call this method.
     int Park();
 
     void RecycleReadBuf(uint16_t bid, size_t bytes);

--- a/src/bthread/ring_listener.h
+++ b/src/bthread/ring_listener.h
@@ -163,9 +163,8 @@ public:
 
     void ExtWakeup();
 
-    // Wakes a worker blocked in WaitForCqe through the poll request registered
-    // on wakeup_event_fd_. This is only used when
-    // FLAGS_brpc_use_event_fd_wakeup was enabled at startup.
+    // Wakes an io_uring worker blocked in WaitForCqe through the poll request
+    // registered on wakeup_event_fd_.
     void NotifyEventFd();
 
     // Blocks the owning worker until this ring has at least one completion.

--- a/src/bthread/ring_listener.h
+++ b/src/bthread/ring_listener.h
@@ -128,17 +128,7 @@ public:
 
     int Init();
 
-    void Close() {
-        if (ring_init_) {
-            io_uring_queue_exit(&ring_);
-            ring_init_ = false;
-        }
-
-        if (in_buf_) {
-            free(in_buf_);
-            in_buf_ = nullptr;
-        }
-    }
+    void Close();
 
     int Register(SocketRegisterData *data);
 
@@ -172,6 +162,16 @@ public:
     size_t ExtPoll();
 
     void ExtWakeup();
+
+    // Wakes a worker blocked in WaitForCqe through the poll request registered
+    // on wakeup_event_fd_. This is only used when
+    // FLAGS_brpc_use_event_fd_wakeup was enabled at startup.
+    void NotifyEventFd();
+
+    // Blocks the owning worker until this ring has at least one completion.
+    // DEFER_TASKRUN requires every io_uring_enter call to come from the ring's
+    // single issuer, so the legacy polling thread must never call this method.
+    int WaitForCqe();
 
     void Run();
 
@@ -209,6 +209,7 @@ private:
         NonFixedWriteFinish,
         WaitingNonFixedWrite,
         Fsync,
+        SchedulerWakeup,
         Noop = 255
     };
 
@@ -232,6 +233,8 @@ private:
                 return 7;
             case OpCode::Fsync:
                 return 8;
+            case OpCode::SchedulerWakeup:
+                return 9;
             default:
                 return UINT8_MAX;
         }
@@ -257,6 +260,8 @@ private:
                 return OpCode::WaitingNonFixedWrite;
             case 8:
                 return OpCode::Fsync;
+            case 9:
+                return OpCode::SchedulerWakeup;
             default:
                 return OpCode::Noop;
         }
@@ -270,6 +275,11 @@ private:
 
     void RecycleReturnedWriteBufs();
 
+    // Installs the persistent multishot poll used for scheduler wakeups.
+    int ArmEventFdPoll();
+
+    void DrainEventFd();
+
     enum struct PollStatus : uint8_t { Active = 0, Sleep, ExtPoll, Closed };
 
     struct io_uring ring_;
@@ -282,6 +292,7 @@ private:
     std::mutex mux_;
     std::condition_variable cv_;
     std::thread poll_thd_;
+    int wakeup_event_fd_{-1};
 
     io_uring_buf_ring *in_buf_ring_{nullptr};
     char *in_buf_{nullptr};

--- a/src/bthread/ring_module.cpp
+++ b/src/bthread/ring_module.cpp
@@ -19,14 +19,10 @@
 
 #include "ring_module.h"
 #include "ring_listener.h"
-#include <atomic>
-
 #ifdef IO_URING_ENABLED
-void RingModule::ExtThdStart(int thd_id) {
-    listeners_.at(thd_id)->has_external_.store(true, std::memory_order_relaxed);
-}
+void RingModule::ExtThdStart(int) {}
 
-void RingModule::ExtThdEnd(int thd_id) { listeners_.at(thd_id)->ExtWakeup(); }
+void RingModule::ExtThdEnd(int) {}
 
 void RingModule::Process(int thd_id) {
     RingListener *listener = listeners_.at(thd_id);

--- a/src/bthread/task_control.cpp
+++ b/src/bthread/task_control.cpp
@@ -41,9 +41,6 @@ DEFINE_int32(task_group_runqueue_capacity, 4096,
 DEFINE_int32(task_group_yield_before_idle, 0,
              "TaskGroup yields so many times before idle");
 DECLARE_bool(use_io_uring);
-#ifdef IO_URING_ENABLED
-DECLARE_bool(brpc_use_event_fd_wakeup);
-#endif
 
 namespace bthread {
 
@@ -284,7 +281,7 @@ void TaskControl::stop_and_join() {
         _pl[i].stop();
     }
 #ifdef IO_URING_ENABLED
-    if (FLAGS_brpc_use_event_fd_wakeup) {
+    if (FLAGS_use_io_uring) {
         // Workers in this mode wait in io_uring rather than on the parking
         // lot. Reuse the scheduler's normal eventfd notification so shutdown
         // does not depend on a signal interrupting io_uring_enter.

--- a/src/bthread/task_control.cpp
+++ b/src/bthread/task_control.cpp
@@ -281,13 +281,10 @@ void TaskControl::stop_and_join() {
         _pl[i].stop();
     }
 #ifdef IO_URING_ENABLED
-    if (FLAGS_use_io_uring) {
-        // Workers in this mode wait in io_uring rather than on the parking
-        // lot. Reuse the scheduler's normal eventfd notification so shutdown
-        // does not depend on a signal interrupting io_uring_enter.
-        for (int i = 0; i < _parking_lot_num; ++i) {
-            _groups[i]->Notify();
-        }
+    // Notify() routes to eventfd when a ring listener exists and otherwise
+    // preserves the condition-variable wakeup path.
+    for (int i = 0; i < _parking_lot_num; ++i) {
+        _groups[i]->Notify();
     }
 #endif
     // Interrupt blocking operations.

--- a/src/bthread/task_control.cpp
+++ b/src/bthread/task_control.cpp
@@ -41,6 +41,9 @@ DEFINE_int32(task_group_runqueue_capacity, 4096,
 DEFINE_int32(task_group_yield_before_idle, 0,
              "TaskGroup yields so many times before idle");
 DECLARE_bool(use_io_uring);
+#ifdef IO_URING_ENABLED
+DECLARE_bool(brpc_use_event_fd_wakeup);
+#endif
 
 namespace bthread {
 
@@ -280,6 +283,16 @@ void TaskControl::stop_and_join() {
     for (int i = 0; i < _parking_lot_num; ++i) {
         _pl[i].stop();
     }
+#ifdef IO_URING_ENABLED
+    if (FLAGS_brpc_use_event_fd_wakeup) {
+        // Workers in this mode wait in io_uring rather than on the parking
+        // lot. Reuse the scheduler's normal eventfd notification so shutdown
+        // does not depend on a signal interrupting io_uring_enter.
+        for (int i = 0; i < _parking_lot_num; ++i) {
+            _groups[i]->Notify();
+        }
+    }
+#endif
     // Interrupt blocking operations.
     for (size_t i = 0; i < _workers.size(); ++i) {
         interrupt_pthread(_workers[i]);

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -1292,13 +1292,11 @@ bool TaskGroup::Wait(){
         // A stop may happen immediately before this worker tries to sleep. A
         // worker that is already blocked is woken through eventfd by
         // TaskControl::stop_and_join().
+        const ParkingLot::State pl_state = _pl->get_state();
 #ifndef BTHREAD_DONT_SAVE_PARKING_STATE
-        _last_pl_state = _pl->get_state();
-        const bool stopped = _last_pl_state.stopped();
-#else
-        const bool stopped = false;
+        _last_pl_state = pl_state;
 #endif
-        if (!stopped && !has_work()) {
+        if (!pl_state.stopped() && !has_work()) {
             ring_listener_->WaitForCqe();
         }
         _notified.store(false, std::memory_order_release);

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -52,9 +52,6 @@ std::atomic<uint64_t> registered_module_version;
 DEFINE_int32(steal_task_rnd, 100, "Steal task frequency in wait_task");
 DEFINE_bool(brpc_worker_as_ext_processor, false, "Work as external processor");
 DECLARE_bool(use_io_uring);
-#ifdef IO_URING_ENABLED
-DECLARE_bool(brpc_use_event_fd_wakeup);
-#endif
 
 namespace bthread {
 
@@ -331,10 +328,6 @@ int TaskGroup::init(size_t runqueue_capacity) {
     _main_stack = stk;
     _last_run_ns = butil::cpuwide_time_ns();
 #ifdef IO_URING_ENABLED
-    if (FLAGS_brpc_use_event_fd_wakeup && !FLAGS_use_io_uring) {
-        LOG(FATAL) << "brpc_use_event_fd_wakeup requires use_io_uring";
-        return -1;
-    }
     if (FLAGS_use_io_uring) {
         ring_listener_ = std::make_unique<RingListener>(this);
         int ret = ring_listener_->Init();
@@ -1229,7 +1222,7 @@ void TaskGroup::Notify() {
         // Only one caller gets the right to notify the worker.
         if (_notified.compare_exchange_strong(expect, true)) {
 #ifdef IO_URING_ENABLED
-            if (FLAGS_brpc_use_event_fd_wakeup) {
+            if (FLAGS_use_io_uring) {
                 ring_listener_->NotifyEventFd();
                 return;
             }
@@ -1247,7 +1240,7 @@ bool TaskGroup::NotifyIfWaiting() {
         // Only one caller gets the right to notify the worker.
         if (_notified.compare_exchange_strong(expect, true)) {
 #ifdef IO_URING_ENABLED
-            if (FLAGS_brpc_use_event_fd_wakeup) {
+            if (FLAGS_use_io_uring) {
                 ring_listener_->NotifyEventFd();
                 return true;
             }
@@ -1286,7 +1279,7 @@ bool TaskGroup::Wait(){
     };
 
 #ifdef IO_URING_ENABLED
-    if (FLAGS_brpc_use_event_fd_wakeup) {
+    if (FLAGS_use_io_uring) {
         // has_work() clears _notified. If a producer races before or after that
         // check, eventfd retains the wakeup until submit_and_wait observes it.
         // A stop may happen immediately before this worker tries to sleep. A

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -1217,7 +1217,7 @@ void TaskGroup::Notify() {
         // Only one caller gets the right to notify the worker.
         if (_notified.compare_exchange_strong(expect, true)) {
 #ifdef IO_URING_ENABLED
-            if (FLAGS_use_io_uring) {
+            if (ring_listener_ != nullptr) {
                 ring_listener_->NotifyEventFd();
                 return;
             }
@@ -1235,7 +1235,7 @@ bool TaskGroup::NotifyIfWaiting() {
         // Only one caller gets the right to notify the worker.
         if (_notified.compare_exchange_strong(expect, true)) {
 #ifdef IO_URING_ENABLED
-            if (FLAGS_use_io_uring) {
+            if (ring_listener_ != nullptr) {
                 ring_listener_->NotifyEventFd();
                 return true;
             }
@@ -1274,7 +1274,7 @@ bool TaskGroup::Wait(){
     };
 
 #ifdef IO_URING_ENABLED
-    if (FLAGS_use_io_uring) {
+    if (ring_listener_ != nullptr) {
         // has_work() clears _notified. If a producer races before or after that
         // check, eventfd retains the wakeup until submit_and_wait observes it.
         // A stop may happen immediately before this worker tries to sleep. A

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -1280,12 +1280,17 @@ bool TaskGroup::Wait(){
         // A stop may happen immediately before this worker tries to sleep. A
         // worker that is already blocked is woken through eventfd by
         // TaskControl::stop_and_join().
-        const ParkingLot::State pl_state = _pl->get_state();
+        while (true) {
+            const ParkingLot::State pl_state = _pl->get_state();
 #ifndef BTHREAD_DONT_SAVE_PARKING_STATE
-        _last_pl_state = pl_state;
+            _last_pl_state = pl_state;
 #endif
-        if (!pl_state.stopped() && !has_work()) {
-            ring_listener_->Park();
+            if (pl_state.stopped() || has_work()) {
+                break;
+            }
+            if (ring_listener_->Park() < 0) {
+                break;
+            }
         }
         _notified.store(false, std::memory_order_release);
     } else

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -193,11 +193,6 @@ bool TaskGroup::wait_task(bthread_t* tid) {
         if (FLAGS_worker_polling_time_us <= 0 ||
             butil::cpuwide_time_us() - poll_start_us > FLAGS_worker_polling_time_us) {
             if (!HasTasks()) {
-#ifdef IO_URING_ENABLED
-                if (FLAGS_use_io_uring && ring_listener_ != nullptr) {
-                    ring_listener_->ExtWakeup();
-                }
-#endif
                 NotifyRegisteredModules(WorkerStatus::Sleep);
 
                 Wait();

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -1285,7 +1285,7 @@ bool TaskGroup::Wait(){
         _last_pl_state = pl_state;
 #endif
         if (!pl_state.stopped() && !has_work()) {
-            ring_listener_->WaitForCqe();
+            ring_listener_->Park();
         }
         _notified.store(false, std::memory_order_release);
     } else

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -52,6 +52,9 @@ std::atomic<uint64_t> registered_module_version;
 DEFINE_int32(steal_task_rnd, 100, "Steal task frequency in wait_task");
 DEFINE_bool(brpc_worker_as_ext_processor, false, "Work as external processor");
 DECLARE_bool(use_io_uring);
+#ifdef IO_URING_ENABLED
+DECLARE_bool(brpc_use_event_fd_wakeup);
+#endif
 
 namespace bthread {
 
@@ -328,6 +331,10 @@ int TaskGroup::init(size_t runqueue_capacity) {
     _main_stack = stk;
     _last_run_ns = butil::cpuwide_time_ns();
 #ifdef IO_URING_ENABLED
+    if (FLAGS_brpc_use_event_fd_wakeup && !FLAGS_use_io_uring) {
+        LOG(FATAL) << "brpc_use_event_fd_wakeup requires use_io_uring";
+        return -1;
+    }
     if (FLAGS_use_io_uring) {
         ring_listener_ = std::make_unique<RingListener>(this);
         int ret = ring_listener_->Init();
@@ -1221,6 +1228,12 @@ void TaskGroup::Notify() {
         bool expect = false;
         // Only one caller gets the right to notify the worker.
         if (_notified.compare_exchange_strong(expect, true)) {
+#ifdef IO_URING_ENABLED
+            if (FLAGS_brpc_use_event_fd_wakeup) {
+                ring_listener_->NotifyEventFd();
+                return;
+            }
+#endif
             std::unique_lock<std::mutex> lk(_mux);
             _notified.store(true, std::memory_order_release);
             _cv.notify_one();
@@ -1233,6 +1246,12 @@ bool TaskGroup::NotifyIfWaiting() {
         bool expect = false;
         // Only one caller gets the right to notify the worker.
         if (_notified.compare_exchange_strong(expect, true)) {
+#ifdef IO_URING_ENABLED
+            if (FLAGS_brpc_use_event_fd_wakeup) {
+                ring_listener_->NotifyEventFd();
+                return true;
+            }
+#endif
             std::unique_lock<std::mutex> lk(_mux);
             _notified.store(true, std::memory_order_release);
             _cv.notify_one();
@@ -1246,10 +1265,7 @@ bool TaskGroup::Wait(){
     _waiting.store(true, std::memory_order_release);
     _waiting_workers.fetch_add(1, std::memory_order_relaxed);
 
-    std::unique_lock<std::mutex> lk(_mux);
-    // Before waiting and sleeping, reset the _notified status.
-    _notified.store(false, std::memory_order_release);
-    _cv.wait(lk, [this]()->bool {
+    const auto has_work = [this]()->bool {
         // Clear the _notified status every time the worker wakes up.
         _notified.store(false, std::memory_order_release);
         // No need to check _rq since _rq can only be pushed by itself.
@@ -1267,7 +1283,31 @@ bool TaskGroup::Wait(){
         // Check any module registered or deleted before checking modules' tasks.
         CheckAndUpdateModules();
         return HasTasks();
-    });
+    };
+
+#ifdef IO_URING_ENABLED
+    if (FLAGS_brpc_use_event_fd_wakeup) {
+        // has_work() clears _notified. If a producer races before or after that
+        // check, eventfd retains the wakeup until submit_and_wait observes it.
+        // A stop may happen immediately before this worker tries to sleep. A
+        // worker that is already blocked is woken through eventfd by
+        // TaskControl::stop_and_join().
+#ifndef BTHREAD_DONT_SAVE_PARKING_STATE
+        _last_pl_state = _pl->get_state();
+        const bool stopped = _last_pl_state.stopped();
+#else
+        const bool stopped = false;
+#endif
+        if (!stopped && !has_work()) {
+            ring_listener_->WaitForCqe();
+        }
+        _notified.store(false, std::memory_order_release);
+    } else
+#endif
+    {
+        std::unique_lock<std::mutex> lk(_mux);
+        _cv.wait(lk, has_work);
+    }
     _waiting.store(false, std::memory_order_release);
     _waiting_workers.fetch_sub(1, std::memory_order_relaxed);
     return true;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

With `use_io_uring=true`, each brpc worker currently owns a separate polling pthread. That pthread waits for CQEs and wakes the worker through a condition variable, adding one thread and a cross-thread handoff per worker and preventing deferred task execution from being driven solely by the ring's issuer.

### What is changed and the side effects?

Changed:

- Make `use_io_uring` the single switch for the optimized scheduler path; there is no separate eventfd-wakeup gflag.
- Create one nonblocking eventfd per io_uring `RingListener` and arm a persistent multishot poll request for scheduler wakeups.
- Let the owning worker block in `io_uring_submit_and_wait()` instead of starting `poll_thd_`.
- Initialize worker rings with `IORING_SETUP_SINGLE_ISSUER`, `IORING_SETUP_DEFER_TASKRUN`, and `IORING_SETUP_TASKRUN_FLAG`.
- Route `TaskGroup::Notify()` and `NotifyIfWaiting()` through eventfd while retaining notification coalescing and lost-wakeup checks.
- Wake workers through eventfd during shutdown so they can observe the stopped parking-lot state.
- Preserve the original polling-thread and condition-variable behavior when `use_io_uring=false`.

Side effects:

- Performance effects(性能影响): io_uring mode removes one polling pthread per worker and its condition-variable handoff. Waking an idle worker instead performs a nonblocking eventfd write.
- Breaking backward compatibility(向后兼容性): non-io_uring users are unchanged. Enabling `use_io_uring` now also requires kernel/liburing support for deferred task execution and multishot poll; initialization fails explicitly when those capabilities are unavailable.

Material design decisions:

- Eventfd wakeup is an implementation detail of io_uring mode, so a second configuration flag and invalid mixed configurations are avoided.
- The multishot poll is expected to remain armed. A CQE without `IORING_CQE_F_MORE` fails fast because silently continuing could permit a future permanent worker sleep.
- `EAGAIN` from eventfd write is success: a saturated eventfd is already readable and therefore already provides the required wakeup.

Verification:

```text
cmake -S /tmp/brpc-eventfd-src -B /tmp/brpc-eventfd-build2 \
  -DIO_URING_ENABLED=ON -DWITH_GLOG=ON \
  -DCMAKE_PREFIX_PATH=/opt/eloq/third_party
PASS

cmake --build /tmp/brpc-eventfd-build2 --parallel 8
PASS (full build; existing compiler warnings only)

git diff --check master...HEAD
PASS
```

The current GitHub Actions compile, format/license, and Bazel jobs have passed; the unit-test job is still running at the time of this update. End-to-end EloqKV and EloqDoc matrices run in the linked dependency-validation PRs.

Performance benchmark (600.004 seconds, read-only GET workload):

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Ops/sec | 399,941.56 | 399,978.18 | +0.01% |
| Average latency | 0.23624 ms | 0.21039 ms | -10.94% |
| p99.9 latency | 0.57500 ms | 0.48700 ms | -15.30% |
| p99.99 latency | 3.08700 ms | 2.60700 ms | -15.55% |
| Throughput | 995,164.74 KB/sec | 995,255.90 KB/sec | +0.01% |

Post-change CPU utilization was 4,248.587 seconds total: 637.575 seconds user and 3,611.012 seconds system. No pre-change CPU measurement was supplied, so no CPU improvement is claimed.

Additional rate-limited memtier samples:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Observed duration | 12.6 sec | 6.1 sec | — |
| Ops/sec | 665,708.44 | 750,805.62 | +12.78% |
| Average latency | 0.48018 ms | 0.42535 ms | -11.42% |
| p99.9 latency | 1.26300 ms | 1.03900 ms | -17.74% |
| p99.99 latency | 3.23100 ms | 2.87900 ms | -10.89% |
| Throughput | 1,656,714.13 KB/sec | 1,869,030.02 KB/sec | +12.82% |

Both rate-limited commands requested 600 seconds but were interrupted with Ctrl+C after unequal short durations. They are supporting observations, not a stable comparison.

Risk / rollback / reviewer focus:

- Primary risks are lost wakeups, shutdown ordering, and preserving the single-issuer invariant.
- Disable `use_io_uring` to restore the legacy runtime path, or revert this PR to retain the previous io_uring polling-thread implementation.
- Please focus on `TaskGroup::Wait()`/`Notify()`, `RingListener::WaitForCqe()`/`HandleCqe()`, and `TaskControl::stop_and_join()`.

---

### Check List:

- [x] I have performed a self-review of my own code
- [x] I have compiled the final diff with io_uring enabled
- [ ] End-to-end dependency-validation CI is complete
