### PR TITLE
feat(eloq): key module registry by type and add a configurable visit order

### DIFF
--- a/src/bthread/eloq_module.cpp
+++ b/src/bthread/eloq_module.cpp
@@ -26,7 +26,7 @@ extern "C" {
 bthread::TaskControl *bthread_get_task_control();
 }
 
-extern std::array<eloq::EloqModule *, eloq::kModuleTypeCount> registered_modules;
+extern std::array<eloq::EloqModule *, eloq::kRegistrySlotCount> registered_modules;
 extern std::atomic<int> registered_module_cnt;
 extern std::atomic<uint64_t> registered_module_version;
 
@@ -40,6 +40,7 @@ namespace eloq {
             {ModuleType::kRing, "ring"},
             {ModuleType::kTxService, "txservice"},
             {ModuleType::kEloqStore, "eloqstore"},
+            {ModuleType::kRuntime, "runtime"},
         };
         static_assert(sizeof(kModuleTypeNames) / sizeof(kModuleTypeNames[0]) ==
                       kModuleTypeCount);
@@ -69,16 +70,36 @@ namespace eloq {
     }
 
     int register_module(EloqModule *module) {
-        // The module's type is its slot, so the registry never shifts and a
-        // slot always denotes the same kind of module.
-        const size_t slot = static_cast<size_t>(module->Type());
-        CHECK_LT(slot, registered_modules.size());
+        // An infrastructure module's type is its slot, so the registry never
+        // shifts and a slot always denotes the same kind of module. Runtime
+        // modules share the [kRuntimeSlotBegin, kRegistrySlotCount) range --
+        // several may coexist in a converged binary -- and take the first free
+        // slot in it; slots are cleared in place on unregister, so a runtime's
+        // slot is likewise stable for as long as it stays registered.
+        const ModuleType type = module->Type();
         std::unique_lock lk(module_mutex);
-        // A module type is a singleton; registering a second instance while
-        // the first is live would silently displace it.
-        CHECK(registered_modules[slot] == nullptr)
-                << "module type " << ModuleTypeName(module->Type())
-                << " is already registered";
+        size_t slot;
+        if (type == ModuleType::kRuntime) {
+            slot = kRuntimeSlotBegin;
+            while (slot < kRegistrySlotCount &&
+                   registered_modules[slot] != nullptr) {
+                CHECK(registered_modules[slot] != module)
+                        << "runtime module is already registered";
+                ++slot;
+            }
+            CHECK_LT(slot, kRegistrySlotCount)
+                    << "more than " << kMaxRuntimeModules
+                    << " runtime modules registered";
+        } else {
+            slot = static_cast<size_t>(type);
+            CHECK_LT(slot, kRuntimeSlotBegin);
+            // An infrastructure module type is a singleton; registering a
+            // second instance while the first is live would silently
+            // displace it.
+            CHECK(registered_modules[slot] == nullptr)
+                    << "module type " << ModuleTypeName(type)
+                    << " is already registered";
+        }
         registered_modules[slot] = module;
         registered_module_cnt.fetch_add(1, std::memory_order_release);
         registered_module_version.fetch_add(1, std::memory_order_release);
@@ -112,15 +133,19 @@ namespace eloq {
             bthread_usleep(1000);
         }
         std::unique_lock lk(module_mutex);
-        const size_t slot = static_cast<size_t>(module->Type());
-        if (slot >= registered_modules.size() ||
-            registered_modules[slot] != module) {
+        // Locate by pointer: a runtime module may sit anywhere in the runtime
+        // range, and an infrastructure slot may have been re-registered by a
+        // newer instance since the existence check above.
+        const auto it = std::find(registered_modules.begin(),
+                                  registered_modules.end(),
+                                  module);
+        if (it == registered_modules.end()) {
             return 0;
         }
         // Clear the slot in place. Compacting the array would renumber every
         // higher module, so a slot would stop denoting the same module across
         // an unregister -- which is what --module_visit_order addresses.
-        registered_modules[slot] = nullptr;
+        *it = nullptr;
         registered_module_cnt.fetch_sub(1, std::memory_order_release);
         registered_module_version.fetch_add(1, std::memory_order_release);
         const auto non_null_modules =

--- a/src/bthread/eloq_module.cpp
+++ b/src/bthread/eloq_module.cpp
@@ -78,13 +78,19 @@ namespace eloq {
         // slot is likewise stable for as long as it stays registered.
         const ModuleType type = module->Type();
         std::unique_lock lk(module_mutex);
+        // Search the whole registry, not just up to the first free slot: a
+        // duplicate can sit after a hole left by another module's unregister,
+        // and registering it again would put the same module in two slots --
+        // visited twice per pass, and unregistered from only one of them.
+        CHECK(std::find(registered_modules.begin(),
+                        registered_modules.end(),
+                        module) == registered_modules.end())
+                << "module is already registered";
         size_t slot;
         if (type == ModuleType::kRuntime) {
             slot = kRuntimeSlotBegin;
             while (slot < kRegistrySlotCount &&
                    registered_modules[slot] != nullptr) {
-                CHECK(registered_modules[slot] != module)
-                        << "runtime module is already registered";
                 ++slot;
             }
             CHECK_LT(slot, kRegistrySlotCount)

--- a/src/bthread/eloq_module.cpp
+++ b/src/bthread/eloq_module.cpp
@@ -26,24 +26,60 @@ extern "C" {
 bthread::TaskControl *bthread_get_task_control();
 }
 
-extern std::array<eloq::EloqModule *, 10> registered_modules;
+extern std::array<eloq::EloqModule *, eloq::kModuleTypeCount> registered_modules;
 extern std::atomic<int> registered_module_cnt;
 extern std::atomic<uint64_t> registered_module_version;
 
 namespace eloq {
+    namespace {
+        struct ModuleTypeNameEntry {
+            ModuleType type_;
+            const char *name_;
+        };
+        constexpr ModuleTypeNameEntry kModuleTypeNames[] = {
+            {ModuleType::kRing, "ring"},
+            {ModuleType::kTxService, "txservice"},
+            {ModuleType::kEloqStore, "eloqstore"},
+        };
+        static_assert(sizeof(kModuleTypeNames) / sizeof(kModuleTypeNames[0]) ==
+                      kModuleTypeCount);
+    }  // namespace
+
+    const char *ModuleTypeName(ModuleType type) {
+        for (const auto &entry : kModuleTypeNames) {
+            if (entry.type_ == type) {
+                return entry.name_;
+            }
+        }
+        return "unknown";
+    }
+
+    bool ParseModuleTypeName(const std::string &name, ModuleType *type) {
+        for (const auto &entry : kModuleTypeNames) {
+            if (name == entry.name_) {
+                *type = entry.type_;
+                return true;
+            }
+        }
+        return false;
+    }
+
     bool EloqModule::NotifyWorker(int thd_id) {
         return bthread_notify_worker(thd_id);
     }
 
     int register_module(EloqModule *module) {
+        // The module's type is its slot, so the registry never shifts and a
+        // slot always denotes the same kind of module.
+        const size_t slot = static_cast<size_t>(module->Type());
+        CHECK_LT(slot, registered_modules.size());
         std::unique_lock lk(module_mutex);
-        size_t i = 0;
-        while (i < registered_modules.size() && registered_modules[i] != nullptr) {
-            // Each module should only be registered once.
-            CHECK(registered_modules[i] != module);
-            i++;
-        }
-        registered_modules[i] = module;
+        // A module type is a singleton; registering a second instance while
+        // the first is live would silently displace it.
+        CHECK(registered_modules[slot] == nullptr)
+                << "module type " << ModuleTypeName(module->Type())
+                << " is already registered";
+        registered_modules[slot] = module;
         registered_module_cnt.fetch_add(1, std::memory_order_release);
         registered_module_version.fetch_add(1, std::memory_order_release);
         const auto non_null_modules =
@@ -76,19 +112,15 @@ namespace eloq {
             bthread_usleep(1000);
         }
         std::unique_lock lk(module_mutex);
-        size_t i = 0;
-        while (i < registered_modules.size() && registered_modules[i] != module) {
-            i++;
-        }
-        if (i == registered_modules.size()) {
+        const size_t slot = static_cast<size_t>(module->Type());
+        if (slot >= registered_modules.size() ||
+            registered_modules[slot] != module) {
             return 0;
         }
-        CHECK(i < registered_module_cnt);
-        while (i < registered_modules.size() - 1) {
-            registered_modules[i] = registered_modules[i + 1];
-            i++;
-        }
-        registered_modules[registered_modules.size() - 1] = nullptr;
+        // Clear the slot in place. Compacting the array would renumber every
+        // higher module, so a slot would stop denoting the same module across
+        // an unregister -- which is what --module_visit_order addresses.
+        registered_modules[slot] = nullptr;
         registered_module_cnt.fetch_sub(1, std::memory_order_release);
         registered_module_version.fetch_add(1, std::memory_order_release);
         const auto non_null_modules =

--- a/src/bthread/eloq_module.h
+++ b/src/bthread/eloq_module.h
@@ -29,23 +29,37 @@ namespace eloq {
     inline std::shared_mutex module_mutex;
 
     /**
-     * Identifies what a module is, independently of when it registers. The
-     * enumerator is also the module's slot in the registry, so a module always
-     * occupies the same slot: the mapping survives a module being absent (e.g.
-     * RingModule when io_uring is off) and a module restarting (e.g. EloqStore
-     * reopening, which happens during normal startup).
+     * Identifies what a module is, independently of when it registers. For the
+     * infrastructure modules the enumerator is also the module's slot in the
+     * registry, so a module always occupies the same slot: the mapping survives
+     * a module being absent (e.g. RingModule when io_uring is off) and a module
+     * restarting (e.g. EloqStore reopening, which happens during normal
+     * startup).
      *
-     * The order is the order the modules settle into after startup, so visiting
-     * every registered slot once in ascending order is the order workers have
-     * always used.
+     * kRuntime is the API-layer runtime driving client requests — the mongo
+     * service executor in EloqDoc, the mariadb thread pool in EloqSQL. Unlike
+     * the infrastructure types it is not a per-process singleton: a converged
+     * binary can host several runtimes at once, so kRuntime maps to a range of
+     * registry slots ([kRuntimeSlotBegin, kRegistrySlotCount)) rather than one,
+     * and a registering runtime takes the first free slot in that range.
      */
     enum class ModuleType : size_t {
         kRing = 0,
         kTxService = 1,
         kEloqStore = 2,
+        kRuntime = 3,
     };
 
-    inline constexpr size_t kModuleTypeCount = 3;
+    inline constexpr size_t kModuleTypeCount = 4;
+
+    /** First registry slot of the runtime range. */
+    inline constexpr size_t kRuntimeSlotBegin =
+            static_cast<size_t>(ModuleType::kRuntime);
+    /** How many runtime modules may be registered at once. */
+    inline constexpr size_t kMaxRuntimeModules = 4;
+    /** Total registry slots: one per infrastructure type + the runtime range. */
+    inline constexpr size_t kRegistrySlotCount =
+            kRuntimeSlotBegin + kMaxRuntimeModules;
 
     /** @brief Stable name of a module type, e.g. "eloqstore". */
     const char *ModuleTypeName(ModuleType type);

--- a/src/bthread/eloq_module.h
+++ b/src/bthread/eloq_module.h
@@ -21,13 +21,50 @@
 #define ELOQ_MODULE_H
 
 #include <atomic>
+#include <cstddef>
 #include <shared_mutex>
+#include <string>
 
 namespace eloq {
     inline std::shared_mutex module_mutex;
+
+    /**
+     * Identifies what a module is, independently of when it registers. The
+     * enumerator is also the module's slot in the registry, so a module always
+     * occupies the same slot: the mapping survives a module being absent (e.g.
+     * RingModule when io_uring is off) and a module restarting (e.g. EloqStore
+     * reopening, which happens during normal startup).
+     *
+     * The order is the order the modules settle into after startup, so visiting
+     * every registered slot once in ascending order is the order workers have
+     * always used.
+     */
+    enum class ModuleType : size_t {
+        kRing = 0,
+        kTxService = 1,
+        kEloqStore = 2,
+    };
+
+    inline constexpr size_t kModuleTypeCount = 3;
+
+    /** @brief Stable name of a module type, e.g. "eloqstore". */
+    const char *ModuleTypeName(ModuleType type);
+
+    /**
+     * @brief Maps a module type name back to its enumerator.
+     * @return true if the name is known, in which case *type is set.
+     */
+    bool ParseModuleTypeName(const std::string &name, ModuleType *type);
+
     class EloqModule {
     public:
         virtual ~EloqModule() = default;
+
+        /**
+         * What this module is. Determines the module's slot in the registry
+         * and the name --module_visit_order uses to refer to it.
+         */
+        virtual ModuleType Type() const = 0;
 
         /**
          * This func is called when worker starts running.

--- a/src/bthread/ring_module.h
+++ b/src/bthread/ring_module.h
@@ -28,6 +28,10 @@ class RingListener;
 
 class RingModule : public eloq::EloqModule {
 public:
+    eloq::ModuleType Type() const override {
+        return eloq::ModuleType::kRing;
+    }
+
     void ExtThdStart(int thd_id) override;
 
     void ExtThdEnd(int thd_id) override;

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -47,7 +47,7 @@
 #include "bthread/ring_listener.h"
 #endif
 
-std::array<eloq::EloqModule *, eloq::kModuleTypeCount> registered_modules;
+std::array<eloq::EloqModule *, eloq::kRegistrySlotCount> registered_modules;
 std::atomic<int> registered_module_cnt;
 std::atomic<uint64_t> registered_module_version;
 
@@ -81,12 +81,14 @@ DEFINE_int32(module_process_latency_log_threshold_us, 0,
              "Log module process latency longer than this threshold (0 disables logging)");
 DEFINE_string(module_visit_order, "",
               "Comma-separated module names giving the visit order of one "
-              "ProcessModulesTask pass. Known names are ring, txservice and "
-              "eloqstore. A name may repeat, which drives that module more "
-              "than once per pass; naming a module that is not registered is "
-              "harmless, it is skipped. Empty selects the default order "
-              "\"ring,eloqstore,txservice,eloqstore\"; pass "
-              "\"ring,txservice,eloqstore\" for one visit each.");
+              "ProcessModulesTask pass. Known names are ring, txservice, "
+              "eloqstore and runtime, where runtime stands for every "
+              "registered API-layer runtime (mongo, mariadb, ...). A name may "
+              "repeat, which drives that module more than once per pass; "
+              "naming a module that is not registered is harmless, it is "
+              "skipped. Empty selects the default order "
+              "\"ring,eloqstore,txservice,eloqstore,runtime\"; pass "
+              "\"ring,txservice,eloqstore,runtime\" for one visit each.");
 
 BAIDU_VOLATILE_THREAD_LOCAL(TaskGroup*, tls_task_group, NULL);
 // Sync with TaskMeta::local_storage when a bthread is created or destroyed.
@@ -316,10 +318,18 @@ static size_t ResolveModuleVisitOrder(
         CHECK(eloq::ParseModuleTypeName(name, &type))
                 << "unknown module name \"" << name << "\" in "
                 << "--module_visit_order=" << spec;
-        CHECK_LT(cnt, order->size())
-                << "--module_visit_order has more than " << order->size()
-                << " entries: " << spec;
-        (*order)[cnt++] = static_cast<uint8_t>(type);
+        // "runtime" stands for every runtime slot: which runtime lives where
+        // is a registration-time detail no deployment should have to know.
+        const size_t slot_begin = static_cast<size_t>(type);
+        const size_t slot_end = type == eloq::ModuleType::kRuntime
+                                        ? eloq::kRegistrySlotCount
+                                        : slot_begin + 1;
+        for (size_t slot = slot_begin; slot < slot_end; ++slot) {
+            CHECK_LT(cnt, order->size())
+                    << "--module_visit_order has more than " << order->size()
+                    << " slot visits: " << spec;
+            (*order)[cnt++] = static_cast<uint8_t>(slot);
+        }
         pos = comma + 1;
     }
     if (cnt == 0) {
@@ -328,20 +338,28 @@ static size_t ResolveModuleVisitOrder(
         // visit per pass can drain, so the second visit shortens the interval
         // between an IO completing and the shard draining it. Benchmarking
         // shows this ahead of one-visit-each on read-heavy load and no worse on
-        // a mixed one. A module that is not registered -- EloqStore under a
-        // different storage backend, Ring without io_uring -- is skipped by the
-        // visit loop, so naming it here costs a null check.
-        static constexpr eloq::ModuleType kDefaultVisitOrder[] = {
-            eloq::ModuleType::kRing,
-            eloq::ModuleType::kEloqStore,
-            eloq::ModuleType::kTxService,
-            eloq::ModuleType::kEloqStore,
+        // a mixed one. The runtime slots come last, matching the registration
+        // order the fixed rotation used to settle into. A slot whose module is
+        // not registered -- EloqStore under a different storage backend, Ring
+        // without io_uring, the runtime range in a process with fewer (or no)
+        // runtimes -- is skipped by the visit loop, so naming it costs a null
+        // check.
+        static constexpr uint8_t kDefaultVisitOrder[] = {
+            static_cast<uint8_t>(eloq::ModuleType::kRing),
+            static_cast<uint8_t>(eloq::ModuleType::kEloqStore),
+            static_cast<uint8_t>(eloq::ModuleType::kTxService),
+            static_cast<uint8_t>(eloq::ModuleType::kEloqStore),
         };
-        static_assert(sizeof(kDefaultVisitOrder) /
-                              sizeof(kDefaultVisitOrder[0]) <=
+        static_assert(sizeof(kDefaultVisitOrder) +
+                              eloq::kMaxRuntimeModules <=
                       TaskGroup::kMaxModuleVisits);
-        for (eloq::ModuleType type : kDefaultVisitOrder) {
-            (*order)[cnt++] = static_cast<uint8_t>(type);
+        for (uint8_t slot : kDefaultVisitOrder) {
+            (*order)[cnt++] = slot;
+        }
+        for (size_t slot = eloq::kRuntimeSlotBegin;
+             slot < eloq::kRegistrySlotCount;
+             ++slot) {
+            (*order)[cnt++] = static_cast<uint8_t>(slot);
         }
     }
     return cnt;

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -81,11 +81,12 @@ DEFINE_int32(module_process_latency_log_threshold_us, 0,
              "Log module process latency longer than this threshold (0 disables logging)");
 DEFINE_string(module_visit_order, "",
               "Comma-separated module names giving the visit order of one "
-              "ProcessModulesTask pass, e.g. \"ring,eloqstore,txservice,"
-              "eloqstore\". Known names are ring, txservice and eloqstore. A "
-              "name may repeat, which drives that module more than once per "
-              "pass; naming a module that is not registered is harmless. Empty "
-              "keeps the default: every module once, in module-type order.");
+              "ProcessModulesTask pass. Known names are ring, txservice and "
+              "eloqstore. A name may repeat, which drives that module more "
+              "than once per pass; naming a module that is not registered is "
+              "harmless, it is skipped. Empty selects the default order "
+              "\"ring,eloqstore,txservice,eloqstore\"; pass "
+              "\"ring,txservice,eloqstore\" for one visit each.");
 
 BAIDU_VOLATILE_THREAD_LOCAL(TaskGroup*, tls_task_group, NULL);
 // Sync with TaskMeta::local_storage when a bthread is created or destroyed.
@@ -322,8 +323,25 @@ static size_t ResolveModuleVisitOrder(
         pos = comma + 1;
     }
     if (cnt == 0) {
-        for (size_t i = 0; i < eloq::kModuleTypeCount; ++i) {
-            (*order)[cnt++] = static_cast<uint8_t>(i);
+        // Default: drive EloqStore twice per pass, once before and once after
+        // the tx service. A shard accumulates completed IO faster than a single
+        // visit per pass can drain, so the second visit shortens the interval
+        // between an IO completing and the shard draining it. Benchmarking
+        // shows this ahead of one-visit-each on read-heavy load and no worse on
+        // a mixed one. A module that is not registered -- EloqStore under a
+        // different storage backend, Ring without io_uring -- is skipped by the
+        // visit loop, so naming it here costs a null check.
+        static constexpr eloq::ModuleType kDefaultVisitOrder[] = {
+            eloq::ModuleType::kRing,
+            eloq::ModuleType::kEloqStore,
+            eloq::ModuleType::kTxService,
+            eloq::ModuleType::kEloqStore,
+        };
+        static_assert(sizeof(kDefaultVisitOrder) /
+                              sizeof(kDefaultVisitOrder[0]) <=
+                      TaskGroup::kMaxModuleVisits);
+        for (eloq::ModuleType type : kDefaultVisitOrder) {
+            (*order)[cnt++] = static_cast<uint8_t>(type);
         }
     }
     return cnt;

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -21,6 +21,8 @@
 
 #include <sys/types.h>
 #include <stddef.h>                         // size_t
+#include <stdint.h>                         // uint8_t
+#include <string>
 #include <typeinfo>
 #include <gflags/gflags.h>
 #include "butil/compat.h"                   // OS_MACOSX
@@ -45,7 +47,7 @@
 #include "bthread/ring_listener.h"
 #endif
 
-std::array<eloq::EloqModule *, 10> registered_modules;
+std::array<eloq::EloqModule *, eloq::kModuleTypeCount> registered_modules;
 std::atomic<int> registered_module_cnt;
 std::atomic<uint64_t> registered_module_version;
 
@@ -77,6 +79,13 @@ DEFINE_int32(worker_polling_time_us, 0, "Worker keep busy polling some time befo
                                        "sleeping on parking lot");
 DEFINE_int32(module_process_latency_log_threshold_us, 0,
              "Log module process latency longer than this threshold (0 disables logging)");
+DEFINE_string(module_visit_order, "",
+              "Comma-separated module names giving the visit order of one "
+              "ProcessModulesTask pass, e.g. \"ring,eloqstore,txservice,"
+              "eloqstore\". Known names are ring, txservice and eloqstore. A "
+              "name may repeat, which drives that module more than once per "
+              "pass; naming a module that is not registered is harmless. Empty "
+              "keeps the default: every module once, in module-type order.");
 
 BAIDU_VOLATILE_THREAD_LOCAL(TaskGroup*, tls_task_group, NULL);
 // Sync with TaskMeta::local_storage when a bthread is created or destroyed.
@@ -286,7 +295,42 @@ TaskGroup::~TaskGroup() {
     }
 }
 
+// Resolves FLAGS_module_visit_order into registry slots, returning how many
+// were written. An unparsable entry aborts rather than silently visiting the
+// wrong module: the flag exists to control which module runs when, so a typo
+// must not look like it worked. An empty flag yields every slot once in
+// module-type order, which is the order workers use when the flag is unset.
+static size_t ResolveModuleVisitOrder(
+        std::array<uint8_t, TaskGroup::kMaxModuleVisits> *order) {
+    const std::string &spec = FLAGS_module_visit_order;
+    size_t cnt = 0;
+    size_t pos = 0;
+    while (pos < spec.size()) {
+        size_t comma = spec.find(',', pos);
+        if (comma == std::string::npos) {
+            comma = spec.size();
+        }
+        const std::string name = spec.substr(pos, comma - pos);
+        eloq::ModuleType type;
+        CHECK(eloq::ParseModuleTypeName(name, &type))
+                << "unknown module name \"" << name << "\" in "
+                << "--module_visit_order=" << spec;
+        CHECK_LT(cnt, order->size())
+                << "--module_visit_order has more than " << order->size()
+                << " entries: " << spec;
+        (*order)[cnt++] = static_cast<uint8_t>(type);
+        pos = comma + 1;
+    }
+    if (cnt == 0) {
+        for (size_t i = 0; i < eloq::kModuleTypeCount; ++i) {
+            (*order)[cnt++] = static_cast<uint8_t>(i);
+        }
+    }
+    return cnt;
+}
+
 int TaskGroup::init(size_t runqueue_capacity) {
+    module_visit_cnt_ = ResolveModuleVisitOrder(&module_visit_order_);
     if (_rq.init(runqueue_capacity) != 0) {
         LOG(FATAL) << "Fail to init _rq";
         return -1;
@@ -1269,7 +1313,10 @@ bool TaskGroup::Wait(){
         }
 
         // Check any module registered or deleted before checking modules' tasks.
-        CheckAndUpdateModules();
+        // This worker is going to sleep, so it must not start anything: the
+        // ExtThdStart() for whatever registers now comes from
+        // NotifyRegisteredModules(Working) when it wakes.
+        CheckAndUpdateModules(false);
         return HasTasks();
     };
 
@@ -1305,18 +1352,17 @@ bool TaskGroup::Wait(){
 }
 
 void TaskGroup::ProcessModulesTask() {
-    int old_modules_cnt = modules_cnt_;
-
-    CheckAndUpdateModules();
-
-    int new_modules_cnt = modules_cnt_;
-    for (int i = old_modules_cnt; i < new_modules_cnt; ++i) {
-        eloq::EloqModule *module = registered_modules_[i];
-        module->ExtThdStart(group_id_);
-    }
+    // Starts modules that are new to this worker. Slots are keyed by module
+    // type and can therefore be sparse, so a module cannot be located by
+    // counting: CheckAndUpdateModules() already diffs the module set and is
+    // the only place that knows which entries are new. This worker is
+    // running, so a module registering now missed the ExtThdStart() that
+    // NotifyRegisteredModules() issues on wake-up and must be started here.
+    CheckAndUpdateModules(true);
 
     const int32_t log_threshold_us = FLAGS_module_process_latency_log_threshold_us;
-    for (auto *module : registered_modules_) {
+    for (size_t i = 0; i < module_visit_cnt_; ++i) {
+        eloq::EloqModule *module = registered_modules_[module_visit_order_[i]];
         if (module == nullptr) {
             continue;
         }
@@ -1347,7 +1393,7 @@ bool TaskGroup::HasTasks() {
     return has_task;
 }
 
-void TaskGroup::CheckAndUpdateModules() {
+void TaskGroup::CheckAndUpdateModules(bool start_new_modules) {
     const uint64_t global_version =
         registered_module_version.load(std::memory_order_acquire);
     if (modules_version_ != global_version) {
@@ -1374,6 +1420,12 @@ void TaskGroup::CheckAndUpdateModules() {
             if (!found) {
                 new_m->registered_workers_.fetch_add(
                     1, std::memory_order_relaxed);
+                // Modules bind per-worker state here (EloqStoreModule binds
+                // the thread's shard), so a module that is never started on a
+                // worker cannot run on it at all.
+                if (start_new_modules) {
+                    new_m->ExtThdStart(group_id_);
+                }
             }
         }
 

--- a/src/bthread/task_group.h
+++ b/src/bthread/task_group.h
@@ -227,9 +227,18 @@ public:
     std::function<bool(bool)> override_shard_heap_{nullptr};
     std::function<bool()> has_tx_processor_work_{nullptr};
 
-    std::array<eloq::EloqModule *, 10> registered_modules_{};
+    std::array<eloq::EloqModule *, eloq::kModuleTypeCount> registered_modules_{};
     int modules_cnt_{0};
     uint64_t modules_version_{0};
+
+    // Registry slots to visit in one ProcessModulesTask() pass, resolved from
+    // --module_visit_order once in init(). Held inline and pre-resolved
+    // because ProcessModulesTask() runs millions of times a second: reading it
+    // must cost no more than the plain array walk it replaced. A slot may
+    // repeat, so the order can be longer than the number of modules.
+    static constexpr size_t kMaxModuleVisits = 8;
+    std::array<uint8_t, kMaxModuleVisits> module_visit_order_{};
+    size_t module_visit_cnt_{0};
 
 #ifdef IO_URING_ENABLED
     int RegisterSocket(SocketRegisterData *data);
@@ -305,7 +314,9 @@ public:
 
     bool HasTasks();
 
-    void CheckAndUpdateModules();
+    // start_new_modules: call ExtThdStart() on modules new to this worker.
+    // Only safe when the worker is running, not when it is going to sleep.
+    void CheckAndUpdateModules(bool start_new_modules);
 
     enum struct WorkerStatus
     {

--- a/src/bthread/task_group.h
+++ b/src/bthread/task_group.h
@@ -227,7 +227,8 @@ public:
     std::function<bool(bool)> override_shard_heap_{nullptr};
     std::function<bool()> has_tx_processor_work_{nullptr};
 
-    std::array<eloq::EloqModule *, eloq::kModuleTypeCount> registered_modules_{};
+    std::array<eloq::EloqModule *, eloq::kRegistrySlotCount>
+        registered_modules_{};
     int modules_cnt_{0};
     uint64_t modules_version_{0};
 
@@ -236,7 +237,7 @@ public:
     // because ProcessModulesTask() runs millions of times a second: reading it
     // must cost no more than the plain array walk it replaced. A slot may
     // repeat, so the order can be longer than the number of modules.
-    static constexpr size_t kMaxModuleVisits = 8;
+    static constexpr size_t kMaxModuleVisits = 16;
     std::array<uint8_t, kMaxModuleVisits> module_visit_order_{};
     size_t module_visit_cnt_{0};
 


### PR DESCRIPTION
## Background

This change comes out of an extended benchmarking effort on EloqKV: driving read-only and 1:1 read/write workload over 10M keys against a memory-limited node, measuring where throughput and tail latency actually go, and turning what we learned into targeted optimizations. Over that effort throughput improved several-fold and the tail latency that motivated the work fell from seconds to milliseconds. This PR is the brpc half of that work; companion PRs land in eloqstore and tx_service.

## The optimization

With `ELOQ_MODULE_ENABLED`, a brpc worker does not just run bthreads — it also drives the ring listener, the tx service, and EloqStore as *modules*, cooperatively multiplexed on its own stack in `ProcessModulesTask()`. Whatever that worker is currently doing, the other roles wait. How often each module is visited per pass is therefore a scheduling decision, and until now it was fixed at "each module once, in whatever order they happened to register".

That order is not optimal. Under read-heavy load the shard accumulates completed IO faster than one visit per pass can drain, so completions wait for the next full rotation. Visiting EloqStore twice per pass — once before and once after the tx service — shortens the gap between an IO completing and the shard draining it.

`--module_visit_order` makes the order configurable, so this is tunable per deployment rather than baked in. Measured on our internal benchmark rig with `--module_visit_order=ring,eloqstore,txservice,eloqstore` against the default, alternating between the two configurations and driving load from a separate client host, the ordering is a consistent win on read-heavy traffic:

- **Read-only throughput improves**, by a small but repeatable margin that grows with connection count. Every ordered run beat every default run, so the effect is separated from run-to-run spread rather than inferred from a single pair.
- **Read latency improves alongside it**, by a comparable relative margin at p99. At the higher connection count the median moves too, not just the tail —which is what the mechanism predicts: the deeper the queue, the more completions are waiting on each pass.
- **Read-write throughput stays within run-to-run variance**, so I make no claim there. Its far tail does improve consistently across every round while the median and p99 stay flat. Writes are gated by checkpoint flush and WAL rather than by read-completion drain, so that shape is expected.

## Change details

**Module identity.** `register_module()` previously assigned the first free slot and `unregister_module()` compacted the array, so a module's index depended on registration order and shifted whenever another module unregistered. EloqStore restarts once during normal startup, which renumbered the tx service underneath it — the registry only settled at ring/txservice/eloqstore *after* that shuffle. Indices were unusable for addressing a module.

`EloqModule` now declares a `ModuleType` — `Ring`, `TxService`, `EloqStore` —and that type *is* the module's slot, so every module has a reserved place in the registry. Registration writes its own slot; unregistration clears it in place. A slot therefore always denotes the same kind of module — across a module being absent (`RingModule` without io_uring) and across a module restarting. Slots may be sparse as a result, which is exactly what makes them stable.

**The flag.** `--module_visit_order` takes module names, e.g. `ring,eloqstore,txservice,eloqstore`. A name may repeat, which drives that module more than once per pass; naming a module that is not registered is harmless. Empty preserves today's behavior exactly: every registered module once, in slot order. The order is resolved once in `TaskGroup::init()` into an inline
fixed-size array — `ProcessModulesTask()` runs millions of times a second, so reading it must not cost a thread-safe-static guard check or a heap indirection per pass. An unknown name aborts at startup rather than silently visiting the wrong module.

**One consequence.** Sparse slots mean a module can no longer be located by counting. `ExtThdStart()` for modules new to a worker moves into `CheckAndUpdateModules()`, which already diffs the module set and runs only when that set changes — so this adds nothing to the per-pass path. The old loop indexed `registered_modules_` with a population count and would skip, or read past, an empty slot. This is not theoretical: `EloqStoreModule::ExtThdStart()` binds the worker's shard pointer, so skipping it left that thread-local null and io_uring initialization aborted at startup.